### PR TITLE
Gravity fix

### DIFF
--- a/Samples/SimpleScene/Assets/Scripts/Physics.lua
+++ b/Samples/SimpleScene/Assets/Scripts/Physics.lua
@@ -1,7 +1,7 @@
 local ecs = require "ecs"
 
 local function rand_flt(from, to)
-	local maxNumber = 32767
+    local maxNumber = 32767
     return from + (math.random(maxNumber) / maxNumber) * (to - from)
 end
 
@@ -9,54 +9,52 @@ local function move(it)
     for pos, vel, ent in ecs.each(it) do
         pos.x = pos.x + vel.x * it.delta_time
         pos.y = pos.y + vel.y * it.delta_time
-		pos.z = pos.z + vel.z * it.delta_time
+        pos.z = pos.z + vel.z * it.delta_time
     end
 end
 
 local function gravity(it)
     for pos, vel, grav, plane, ent in ecs.each(it) do
         local planeEpsilon = 0.1
-		
-		if plane.x * pos.x + plane.y * pos.y + plane.z * pos.z < plane.w + planeEpsilon then
-			do return end
-		end
-		
-		vel.x = vel.x + grav.x * it.delta_time
-        vel.y = vel.y + grav.y * it.delta_time
-		vel.z = vel.z + grav.z * it.delta_time
+
+        if plane.x * pos.x + plane.y * pos.y + plane.z * pos.z > plane.w + planeEpsilon then
+            vel.x = vel.x + grav.x * it.delta_time
+            vel.y = vel.y + grav.y * it.delta_time
+            vel.z = vel.z + grav.z * it.delta_time
+        end
     end
 end
 
 local function FrictionSystem(it)
     for vel, friction, ent in ecs.each(it) do
         vel.x = vel.x - vel.x * friction.value * it.delta_time
-		vel.y = vel.y - vel.y * friction.value * it.delta_time
-		vel.z = vel.z - vel.z * friction.value * it.delta_time
+        vel.y = vel.y - vel.y * friction.value * it.delta_time
+        vel.z = vel.z - vel.z * friction.value * it.delta_time
     end
 end
 
 local function ShiverSystem(it)
     for pos, shiver, ent in ecs.each(it) do
         pos.x = pos.x + rand_flt(-shiver.value, shiver.value)
-		pos.y = pos.y + rand_flt(-shiver.value, shiver.value)
-		pos.z = pos.z + rand_flt(-shiver.value, shiver.value)
+        pos.y = pos.y + rand_flt(-shiver.value, shiver.value)
+        pos.z = pos.z + rand_flt(-shiver.value, shiver.value)
     end
 end
 
 local function BounceSystem(it)
     for pos, vel, plane, bounciness, ent in ecs.each(it) do
         local dotPos = plane.x * pos.x + plane.y * pos.y + plane.z * pos.z
-		local dotVel = plane.x * vel.x + plane.y * vel.y + plane.z * vel.z
-		
-		if dotPos < plane.w then
-			pos.x = pos.x - (dotPos - plane.w) * plane.x
-			pos.y = pos.y - (dotPos - plane.w) * plane.y
-			pos.z = pos.z - (dotPos - plane.w) * plane.z
+        local dotVel = plane.x * vel.x + plane.y * vel.y + plane.z * vel.z
 
-			vel.x = vel.x - (1.0 + bounciness.value) * plane.x * dotVel
-			vel.y = vel.y - (1.0 + bounciness.value) * plane.y * dotVel
-			vel.z = vel.z - (1.0 + bounciness.value) * plane.z * dotVel
-		end
+        if dotPos < plane.w then
+            pos.x = pos.x - (dotPos - plane.w) * plane.x
+            pos.y = pos.y - (dotPos - plane.w) * plane.y
+            pos.z = pos.z - (dotPos - plane.w) * plane.z
+
+            vel.x = vel.x - (1.0 + bounciness.value) * plane.x * dotVel
+            vel.y = vel.y - (1.0 + bounciness.value) * plane.y * dotVel
+            vel.z = vel.z - (1.0 + bounciness.value) * plane.z * dotVel
+        end
     end
 end
 
@@ -65,4 +63,3 @@ ecs.system(gravity, "grav", ecs.OnUpdate, "Position, Velocity, Gravity, BouncePl
 ecs.system(FrictionSystem, "FrictionSystem", ecs.OnUpdate, "Velocity, FrictionAmount")
 ecs.system(ShiverSystem, "ShiverSystem", ecs.OnUpdate, "Position, ShiverAmount")
 ecs.system(BounceSystem, "BounceSystem", ecs.OnUpdate, "Position, Velocity, BouncePlane, Bounciness")
-


### PR DESCRIPTION
# Gravity fix

## Bug

There is a bug with the way gravity is applied to objects.

In the [`gravity`](https://github.com/lesina/GameEngineDevelopingCourse/blob/c8e427dd8dafccac21180db2aab2d4f6338d3ad2/Samples/SimpleScene/Assets/Scripts/Physics.lua#L20-L22) function of the [`physics.lua`](https://github.com/lesina/GameEngineDevelopingCourse/blob/Lesson06/Samples/SimpleScene/Assets/Scripts/Physics.lua) script if one object is continuously touching the ground, it can prevent other objects from receiving velocity updates.

The bug is probably present in other branches of the project, presumably from `Lesson05`.

## Fix

Restructured the branch so it does not stop query processing.

## Minor Changes

Not sure if this was intentional or not, but indentation was inconsistent, changing between tabs and spaces mid-block.
I know the repo was never supposed to be an exemplary piece of code, and I am not critiquing it in any way.
It's just that VSCode was forcing consistent indentation style on me, and I was too lazy to disable the feature.